### PR TITLE
Add build command for project nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,89 @@
 # dotnet-solution-explorer.nvim
-Support to Solution Explorer for NeoVim
 
-## Build current project
+A Neo-tree source that brings a Visual Studio style Solution Explorer to Neovim. It parses `.sln` files and MSBuild projects so you can browse, build and run .NET solutions without leaving the editor.
 
-When the cursor is on a project node you can compile it using the command:
+## Features
 
+- Displays the full solution tree including projects and folders
+- Shows the target framework next to each project
+- Build, run or create new files directly from the tree
+- Supports .NET Framework on Windows and SDK style projects on any platform
+
+## Requirements
+
+- [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim)
+- [plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
+- The `dotnet` CLI for .NET Core/NET projects
+- Visual Studio Build Tools when compiling .NET Framework projects on Windows
+
+## Installation
+
+### Using lazy.nvim
+
+```lua
+{
+  "your-user/dotnet-solution-explorer.nvim",
+  dependencies = { "nvim-neo-tree/neo-tree.nvim", "nvim-lua/plenary.nvim" },
+  config = function()
+    require("dotnet-solution-explorer").setup({
+      follow_current_file = { enabled = true },
+    })
+  end,
+}
 ```
-:DotNetBuild
-```
 
-It is also possible to map a key inside the Neo-tree window. Example:
+Add `"dotnet_solution"` to the `sources` list of Neo-tree:
 
 ```lua
 require("neo-tree").setup({
-    sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
-    window = {
-        mappings = {
-            ["B"] = "build_project",
-        },
-    },
+  sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
 })
 ```
 
-## Run current project
+### Using packer.nvim
 
-When a .NET project is selected you can execute it with:
-
+```lua
+use {
+  "your-user/dotnet-solution-explorer.nvim",
+  requires = { "nvim-neo-tree/neo-tree.nvim", "nvim-lua/plenary.nvim" },
+  config = function()
+    require("dotnet-solution-explorer").setup({})
+  end,
+}
 ```
-:DotNetRun
-```
 
-Example key mapping inside Neo-tree:
+## Commands
+
+- `:DotNetBuild` – compile the project under the cursor
+- `:DotNetRun` – run the selected project using `dotnet run` or the built executable
+- `:DotNetAddFile` – create a new file inside the current folder and update the project
+
+You can map these inside the Neo-tree window. For example:
 
 ```lua
 require("neo-tree").setup({
-    sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
-    window = {
-        mappings = {
-            ["R"] = "run_project",
-        },
+  sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
+  window = {
+    mappings = {
+      ["B"] = "build_project",
+      ["R"] = "run_project",
+      ["a"] = "add_file",
     },
+  },
 })
 ```
 
-## Create files
+## Contributing
 
-Inside a project folder you can create a new file with:
+1. Fork the repository and create a new branch for your changes.
+2. Make your edits and ensure all Lua files parse correctly:
+   ```bash
+   luac -p $(find lua -name '*.lua')
+   ```
+3. Submit a pull request describing your changes.
 
-```
-:DotNetAddFile
-```
+Bug reports, feature requests and contributions are very welcome!
 
-Mapping the `a` key in Neo-tree:
+## License
 
-```lua
-require("neo-tree").setup({
-    sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
-    window = {
-        mappings = {
-            ["a"] = "add_file",
-        },
-    },
-})
-```
+MIT

--- a/README.md
+++ b/README.md
@@ -21,3 +21,24 @@ require("neo-tree").setup({
     },
 })
 ```
+
+## Run current project
+
+When a .NET project is selected you can execute it with:
+
+```
+:DotNetRun
+```
+
+Example key mapping inside Neo-tree:
+
+```lua
+require("neo-tree").setup({
+    sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
+    window = {
+        mappings = {
+            ["R"] = "run_project",
+        },
+    },
+})
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Support to Solution Explorer for NeoVim
 When the cursor is on a project node you can compile it using the command:
 
 ```
-:DotNetFrameworkBuild
+:DotNetBuild
 ```
 
 It is also possible to map a key inside the Neo-tree window. Example:

--- a/README.md
+++ b/README.md
@@ -42,3 +42,24 @@ require("neo-tree").setup({
     },
 })
 ```
+
+## Create files
+
+Inside a project folder you can create a new file with:
+
+```
+:DotNetAddFile
+```
+
+Mapping the `a` key in Neo-tree:
+
+```lua
+require("neo-tree").setup({
+    sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
+    window = {
+        mappings = {
+            ["a"] = "add_file",
+        },
+    },
+})
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # dotnet-solution-explorer.nvim
 Support to Solution Explorer for NeoVim
+
+## Build current project
+
+When the cursor is on a project node you can compile it using the command:
+
+```
+:DotNetFrameworkBuild
+```
+
+It is also possible to map a key inside the Neo-tree window. Example:
+
+```lua
+require("neo-tree").setup({
+    sources = { "filesystem", "buffers", "git_status", "document_symbols", "dotnet_solution" },
+    window = {
+        mappings = {
+            ["B"] = "build_project",
+        },
+    },
+})
+```

--- a/lua/dotnet-solution-explorer/commands.lua
+++ b/lua/dotnet-solution-explorer/commands.lua
@@ -14,9 +14,13 @@ M.show_debug_info = function(state)
 end
 
 M.set_default_project = function(state)
-	local tree = state.tree
-	local node = tree:get_node()
-	local id = node:get_id()
+        local tree = state.tree
+        local node = tree:get_node()
+        local id = node:get_id()
+end
+
+M.build_project = function(state)
+        require("dotnet-solution-explorer").build_current_project()
 end
 
 cc._add_common_commands(M)

--- a/lua/dotnet-solution-explorer/commands.lua
+++ b/lua/dotnet-solution-explorer/commands.lua
@@ -27,5 +27,9 @@ M.run_project = function(state)
         require("dotnet-solution-explorer").run_current_project()
 end
 
+M.add_file = function(state)
+        require("dotnet-solution-explorer").create_new_file()
+end
+
 cc._add_common_commands(M)
 return M

--- a/lua/dotnet-solution-explorer/commands.lua
+++ b/lua/dotnet-solution-explorer/commands.lua
@@ -23,5 +23,9 @@ M.build_project = function(state)
         require("dotnet-solution-explorer").build_current_project()
 end
 
+M.run_project = function(state)
+        require("dotnet-solution-explorer").run_current_project()
+end
+
 cc._add_common_commands(M)
 return M

--- a/lua/dotnet-solution-explorer/init.lua
+++ b/lua/dotnet-solution-explorer/init.lua
@@ -199,15 +199,15 @@ local function project_to_node(state, proj, known_nodes)
 	end
 	known_nodes[proj.fullPath] = true
 
-        local node = {
-                id = proj.fullPath,
-                name = proj.projectName,
-                path = proj.fullPath,
-                type = "directory",
-                icon = (proj.projectType == "solutionFolder") and ICONS.FOLDER or ICONS.PROJECT,
-                children = {},
-                kind = proj.kind,
-        }
+       local node = {
+               id = proj.fullPath,
+               name = proj.projectName,
+               path = proj.fullPath,
+               type = "directory",
+               icon = (proj.projectType == "solutionFolder") and ICONS.FOLDER or ICONS.PROJECT,
+               children = {},
+               kind = proj.kind,
+       }
 
 	if
 		proj.projectType == "knownToBeMSBuildFormat"
@@ -226,6 +226,9 @@ local function project_to_node(state, proj, known_nodes)
 
                node.kind = proj.kind
                node.runtime = proj.runtime
+               if proj.runtime then
+                       node.name = string.format("%s (%s)", proj.projectName, proj.runtime)
+               end
 
 		if project_tree and project_tree.children then
 			for _, item in ipairs(project_tree.children) do
@@ -701,6 +704,11 @@ local function compile_project_dotnet(project_info)
        build_job:start()
 end
 
+local function run_project_dotnet(project_info)
+       local cmd = { "dotnet", "run", "--project", project_info.path }
+       vim.fn.termopen(cmd)
+end
+
 local function get_iis_express_path()
 	local program_files = os.getenv("ProgramFiles(x86)") or os.getenv("ProgramFiles")
 	local paths = {
@@ -856,10 +864,43 @@ function M.build_current_project()
        end
 end
 
+function M.run_current_project()
+       local state = require("neo-tree.sources.manager").get_state(M.name)
+       if not state or not state.tree then
+               return
+       end
+
+       local node = state.tree:get_node()
+       if not node or not node.path or not node.path:match("%.csproj$") then
+               vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
+               return
+       end
+
+       local project_info = {
+               path = node.path,
+               name = node.name,
+               kind = node.kind or "console",
+               runtime = node.runtime,
+       }
+
+       if not is_dotnet_cli_runtime(project_info.runtime) then
+               vim.notify("DotNetRun solo soporta proyectos .NET", vim.log.levels.ERROR)
+               return
+       end
+
+       if vim.fn.executable("dotnet") ~= 1 then
+               vim.notify("dotnet CLI no encontrada en el PATH", vim.log.levels.ERROR)
+               return
+       end
+
+       run_project_dotnet(project_info)
+end
+
 -- Comando de usuario
 vim.api.nvim_create_user_command("DotNetFrameworkRun", M.build_and_run, {})
 vim.api.nvim_create_user_command("DotNetFrameworkBuild", M.build_current_project, {})
 vim.api.nvim_create_user_command("DotNetBuild", M.build_current_project, {})
+vim.api.nvim_create_user_command("DotNetRun", M.run_current_project, {})
 
 -- Autodetección de entorno al cargar el plugin
 vim.schedule(function()

--- a/lua/dotnet-solution-explorer/init.lua
+++ b/lua/dotnet-solution-explorer/init.lua
@@ -29,6 +29,32 @@ local ICONS = {
 
 local SPINNER_FRAMES = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
 
+local function is_net_framework(runtime)
+       if not runtime then
+               return false
+       end
+       runtime = runtime:lower()
+       if runtime:match("^netstandard") then
+               return false
+       end
+       return runtime:match("^net[1-4]") ~= nil
+end
+
+local function is_dotnet_cli_runtime(runtime)
+       if not runtime then
+               return false
+       end
+       runtime = runtime:lower()
+       if runtime:match("^netcoreapp") or runtime:match("^netstandard") then
+               return true
+       end
+       local major = runtime:match("^net(%d)")
+       if major and tonumber(major) and tonumber(major) >= 5 then
+               return true
+       end
+       return false
+end
+
 local function debug_log(message, data)
 	-- print(string.format("[Solution Explorer Debug] %s -> %s", message, vim.inspect(data)))
 end
@@ -104,12 +130,16 @@ local function parse_project_safe(proj_path)
 		return nil
 	end
 
-	debug_log("Successfully parsed project", {
-		path = proj_path,
-		runtime = result.runtime,
-		child_count = result.children and #result.children or 0,
-	})
-	return result
+        debug_log("Successfully parsed project", {
+                path = proj_path,
+                runtime = result.runtime,
+                child_count = result.children and #result.children or 0,
+        })
+
+       if result.runtime and is_net_framework(result.runtime) and vim.fn.has("win32") ~= 1 then
+               vim.notify("Los proyectos de .NET Framework solo funcionan en Windows", vim.log.levels.ERROR)
+       end
+        return result
 end
 
 local function create_tree_node(item, project_guid, base_path, known_nodes)
@@ -184,16 +214,18 @@ local function project_to_node(state, proj, known_nodes)
 		or proj.projectType == "webProject"
 		or proj.projectType == "webDeploymentProject"
 	then
-                local project_tree = state.project_trees[proj.fullPath]
-                if not project_tree then
-                        project_tree = parse_project_safe(proj.fullPath)
-                        if project_tree then
-                                proj.kind = project_tree.kind
-                                state.project_trees[proj.fullPath] = project_tree
-                        end
-                end
+               local project_tree = state.project_trees[proj.fullPath]
+               if not project_tree then
+                       project_tree = parse_project_safe(proj.fullPath)
+                       if project_tree then
+                               proj.kind = project_tree.kind
+                               proj.runtime = project_tree.runtime
+                               state.project_trees[proj.fullPath] = project_tree
+                       end
+               end
 
-                node.kind = proj.kind
+               node.kind = proj.kind
+               node.runtime = proj.runtime
 
 		if project_tree and project_tree.children then
 			for _, item in ipairs(project_tree.children) do
@@ -615,7 +647,7 @@ local function build_project(msbuild_path, project_info)
 	build_job:start()
 end
 
-local function compile_project(msbuild_path, project_info)
+local function compile_project_msbuild(msbuild_path, project_info)
         local project_path = project_info.path
         vim.notify(string.format("Compilando %s (%s)...", project_info.name, project_info.kind:upper()))
 
@@ -643,6 +675,30 @@ local function compile_project(msbuild_path, project_info)
                 end,
         })
         build_job:start()
+end
+
+local function compile_project_dotnet(project_info)
+       local project_path = project_info.path
+       vim.notify(string.format("Compilando %s (%s)...", project_info.name, project_info.kind:upper()))
+
+       local build_job = Job:new({
+               command = "dotnet",
+               args = { "build", project_path },
+               on_stdout = function(_, data)
+                       print(data)
+               end,
+               on_stderr = function(_, data)
+                       vim.notify(data, vim.log.levels.ERROR)
+               end,
+               on_exit = function(_, code)
+                       if code == 0 then
+                               vim.notify("✓ Compilación exitosa!", vim.log.levels.INFO)
+                       else
+                               vim.notify("✗ Error en la compilación", vim.log.levels.ERROR)
+                       end
+               end,
+       })
+       build_job:start()
 end
 
 local function get_iis_express_path()
@@ -755,40 +811,55 @@ function M.build_and_run()
 end
 
 function M.build_current_project()
-        local state = require("neo-tree.sources.manager").get_state(M.name)
-        if not state or not state.tree then
-                return
-        end
-        local node = state.tree:get_node()
-        if not node or not node.path or not node.path:match("%.csproj$") then
-                vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
-                return
-        end
+       local state = require("neo-tree.sources.manager").get_state(M.name)
+       if not state or not state.tree then
+               return
+       end
+       local node = state.tree:get_node()
+       if not node or not node.path or not node.path:match("%.csproj$") then
+               vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
+               return
+       end
 
-        local project_info = {
-                path = node.path,
-                name = node.name,
-                kind = node.kind or "library",
-        }
+       local project_info = {
+               path = node.path,
+               name = node.name,
+               kind = node.kind or "library",
+               runtime = node.runtime,
+       }
 
-        local msbuild_path = find_msbuild()
-        if not msbuild_path then
-                vim.ui.select({ "Sí", "No" }, {
-                        prompt = "MSBuild no encontrado. ¿Instalar Build Tools?",
-                }, function(choice)
-                        if choice == "Sí" then
-                                install_build_tools()
-                        end
-                end)
-                return
-        end
+       if project_info.runtime and is_net_framework(project_info.runtime) then
+               if vim.fn.has("win32") ~= 1 then
+                       vim.notify("Los proyectos de .NET Framework solo funcionan en Windows", vim.log.levels.ERROR)
+                       return
+               end
 
-        compile_project(msbuild_path, project_info)
+               local msbuild_path = find_msbuild()
+               if not msbuild_path then
+                       vim.ui.select({ "Sí", "No" }, {
+                               prompt = "MSBuild no encontrado. ¿Instalar Build Tools?",
+                       }, function(choice)
+                               if choice == "Sí" then
+                                       install_build_tools()
+                               end
+                       end)
+                       return
+               end
+
+               compile_project_msbuild(msbuild_path, project_info)
+       else
+               if vim.fn.executable("dotnet") ~= 1 then
+                       vim.notify("dotnet CLI no encontrada en el PATH", vim.log.levels.ERROR)
+                       return
+               end
+               compile_project_dotnet(project_info)
+       end
 end
 
 -- Comando de usuario
 vim.api.nvim_create_user_command("DotNetFrameworkRun", M.build_and_run, {})
 vim.api.nvim_create_user_command("DotNetFrameworkBuild", M.build_current_project, {})
+vim.api.nvim_create_user_command("DotNetBuild", M.build_current_project, {})
 
 -- Autodetección de entorno al cargar el plugin
 vim.schedule(function()

--- a/lua/dotnet-solution-explorer/init.lua
+++ b/lua/dotnet-solution-explorer/init.lua
@@ -130,7 +130,7 @@ local function parse_project_safe(proj_path)
 		return nil
 	end
 
-        debug_log("Successfully parsed project", {
+       debug_log("Successfully parsed project", {
                 path = proj_path,
                 runtime = result.runtime,
                 child_count = result.children and #result.children or 0,
@@ -220,12 +220,14 @@ local function project_to_node(state, proj, known_nodes)
                        if project_tree then
                                proj.kind = project_tree.kind
                                proj.runtime = project_tree.runtime
+                               proj.is_sdk_style = project_tree.is_sdk_style
                                state.project_trees[proj.fullPath] = project_tree
                        end
                end
 
                node.kind = proj.kind
                node.runtime = proj.runtime
+               node.is_sdk_style = proj.is_sdk_style
                if proj.runtime then
                        node.name = string.format("%s (%s)", proj.projectName, proj.runtime)
                end
@@ -444,6 +446,25 @@ local function find_solution(path)
 		current = vim.fn.fnamemodify(current, ":h")
 	end
 	return nil
+end
+
+local function find_project_for_path(state, file_path)
+       if not state.parsed_solution then
+               return nil
+       end
+
+       file_path = path_utils.normalize_path(file_path)
+
+       for _, proj in ipairs(state.parsed_solution:projects()) do
+               if proj.projectType ~= "solutionFolder" then
+                       local proj_dir = Path:new(proj.fullPath):parent():absolute()
+                       if file_path:sub(1, #proj_dir) == proj_dir then
+                               return proj
+                       end
+               end
+       end
+
+       return nil
 end
 
 local function projects_picker(state)
@@ -709,6 +730,34 @@ local function run_project_dotnet(project_info)
        vim.fn.termopen(cmd)
 end
 
+local function add_file_to_csproj(csproj_path, rel_path)
+       local lines = vim.fn.readfile(csproj_path)
+       local insert_pos = nil
+       for idx, line in ipairs(lines) do
+               if line:match("</ItemGroup>") then
+                       insert_pos = idx
+                       break
+               end
+       end
+
+       local compile_line = string.format('    <Compile Include="%s" />', rel_path)
+
+       if insert_pos then
+               table.insert(lines, insert_pos, compile_line)
+       else
+               table.insert(lines, #lines, '  <ItemGroup>')
+               table.insert(lines, #lines, compile_line)
+               table.insert(lines, #lines, '  </ItemGroup>')
+       end
+
+       vim.fn.writefile(lines, csproj_path)
+end
+
+local function create_file(full_path, template)
+       Path:new(full_path):write(template or "", "w")
+end
+
+
 local function get_iis_express_path()
 	local program_files = os.getenv("ProgramFiles(x86)") or os.getenv("ProgramFiles")
 	local paths = {
@@ -896,11 +945,66 @@ function M.run_current_project()
        run_project_dotnet(project_info)
 end
 
+function M.create_new_file()
+       local state = require("neo-tree.sources.manager").get_state(M.name)
+       if not state or not state.tree then
+               return
+       end
+
+       local node = state.tree:get_node()
+       if not node then
+               return
+       end
+
+       local dir_path = node.path
+       if node.type ~= "directory" then
+               dir_path = Path:new(node.path):parent():absolute()
+       elseif dir_path:match("%.csproj$") then
+               dir_path = Path:new(dir_path):parent():absolute()
+       end
+
+       vim.ui.input({ prompt = "Nombre del archivo:" }, function(input)
+               if not input or input == "" then
+                       return
+               end
+
+               local full_path = Path:new(dir_path, input):absolute()
+               if vim.fn.filereadable(full_path) == 1 then
+                       vim.notify("El archivo ya existe", vim.log.levels.ERROR)
+                       return
+               end
+
+               local template = ""
+               if input:match("%.cs$") then
+                       local class_name = input:gsub("%.cs$", "")
+                       template = string.format("public class %s\n{\n}\n", class_name)
+               end
+
+               create_file(full_path, template)
+
+               local proj = find_project_for_path(state, full_path)
+               if proj then
+                       local proj_tree = state.project_trees[proj.fullPath]
+                       if proj_tree and not proj_tree.is_sdk_style then
+                               local proj_dir = Path:new(proj.fullPath):parent():absolute()
+                               local rel = Path:new(full_path):make_relative(proj_dir)
+                               add_file_to_csproj(proj.fullPath, rel)
+                       end
+               end
+
+               state.last_scan = 0
+               manager.refresh(M.name)
+
+               vim.cmd("edit " .. full_path)
+       end)
+end
+
 -- Comando de usuario
 vim.api.nvim_create_user_command("DotNetFrameworkRun", M.build_and_run, {})
 vim.api.nvim_create_user_command("DotNetFrameworkBuild", M.build_current_project, {})
 vim.api.nvim_create_user_command("DotNetBuild", M.build_current_project, {})
 vim.api.nvim_create_user_command("DotNetRun", M.run_current_project, {})
+vim.api.nvim_create_user_command("DotNetAddFile", M.create_new_file, {})
 
 -- Autodetección de entorno al cargar el plugin
 vim.schedule(function()

--- a/lua/dotnet-solution-explorer/init.lua
+++ b/lua/dotnet-solution-explorer/init.lua
@@ -8,7 +8,7 @@ local Path = require("plenary.path")
 
 local solution_file = require("dotnet-solution-explorer.solution_file")
 local project_parser = require("dotnet-solution-explorer.project_parser")
-local path_utils = require("utils.path")
+local path_utils = require("dotnet-solution-explorer.utils.path")
 
 local M = {
 	name = "dotnet_solution",
@@ -30,29 +30,29 @@ local ICONS = {
 local SPINNER_FRAMES = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" }
 
 local function is_net_framework(runtime)
-       if not runtime then
-               return false
-       end
-       runtime = runtime:lower()
-       if runtime:match("^netstandard") then
-               return false
-       end
-       return runtime:match("^net[1-4]") ~= nil
+	if not runtime then
+		return false
+	end
+	runtime = runtime:lower()
+	if runtime:match("^netstandard") then
+		return false
+	end
+	return runtime:match("^net[1-4]") ~= nil
 end
 
 local function is_dotnet_cli_runtime(runtime)
-       if not runtime then
-               return false
-       end
-       runtime = runtime:lower()
-       if runtime:match("^netcoreapp") or runtime:match("^netstandard") then
-               return true
-       end
-       local major = runtime:match("^net(%d)")
-       if major and tonumber(major) and tonumber(major) >= 5 then
-               return true
-       end
-       return false
+	if not runtime then
+		return false
+	end
+	runtime = runtime:lower()
+	if runtime:match("^netcoreapp") or runtime:match("^netstandard") then
+		return true
+	end
+	local major = runtime:match("^net(%d)")
+	if major and tonumber(major) and tonumber(major) >= 5 then
+		return true
+	end
+	return false
 end
 
 local function debug_log(message, data)
@@ -130,16 +130,16 @@ local function parse_project_safe(proj_path)
 		return nil
 	end
 
-       debug_log("Successfully parsed project", {
-                path = proj_path,
-                runtime = result.runtime,
-                child_count = result.children and #result.children or 0,
-        })
+	debug_log("Successfully parsed project", {
+		path = proj_path,
+		runtime = result.runtime,
+		child_count = result.children and #result.children or 0,
+	})
 
-       if result.runtime and is_net_framework(result.runtime) and vim.fn.has("win32") ~= 1 then
-               vim.notify("Los proyectos de .NET Framework solo funcionan en Windows", vim.log.levels.ERROR)
-       end
-        return result
+	if result.runtime and is_net_framework(result.runtime) and vim.fn.has("win32") ~= 1 then
+		vim.notify("Los proyectos de .NET Framework solo funcionan en Windows", vim.log.levels.ERROR)
+	end
+	return result
 end
 
 local function create_tree_node(item, project_guid, base_path, known_nodes)
@@ -199,38 +199,38 @@ local function project_to_node(state, proj, known_nodes)
 	end
 	known_nodes[proj.fullPath] = true
 
-       local node = {
-               id = proj.fullPath,
-               name = proj.projectName,
-               path = proj.fullPath,
-               type = "directory",
-               icon = (proj.projectType == "solutionFolder") and ICONS.FOLDER or ICONS.PROJECT,
-               children = {},
-               kind = proj.kind,
-       }
+	local node = {
+		id = proj.fullPath,
+		name = proj.projectName,
+		path = proj.fullPath,
+		type = "directory",
+		icon = (proj.projectType == "solutionFolder") and ICONS.FOLDER or ICONS.PROJECT,
+		children = {},
+		kind = proj.kind,
+	}
 
 	if
 		proj.projectType == "knownToBeMSBuildFormat"
 		or proj.projectType == "webProject"
 		or proj.projectType == "webDeploymentProject"
 	then
-               local project_tree = state.project_trees[proj.fullPath]
-               if not project_tree then
-                       project_tree = parse_project_safe(proj.fullPath)
-                       if project_tree then
-                               proj.kind = project_tree.kind
-                               proj.runtime = project_tree.runtime
-                               proj.is_sdk_style = project_tree.is_sdk_style
-                               state.project_trees[proj.fullPath] = project_tree
-                       end
-               end
+		local project_tree = state.project_trees[proj.fullPath]
+		if not project_tree then
+			project_tree = parse_project_safe(proj.fullPath)
+			if project_tree then
+				proj.kind = project_tree.kind
+				proj.runtime = project_tree.runtime
+				proj.is_sdk_style = project_tree.is_sdk_style
+				state.project_trees[proj.fullPath] = project_tree
+			end
+		end
 
-               node.kind = proj.kind
-               node.runtime = proj.runtime
-               node.is_sdk_style = proj.is_sdk_style
-               if proj.runtime then
-                       node.name = string.format("%s (%s)", proj.projectName, proj.runtime)
-               end
+		node.kind = proj.kind
+		node.runtime = proj.runtime
+		node.is_sdk_style = proj.is_sdk_style
+		if proj.runtime then
+			node.name = string.format("%s (%s)", proj.projectName, proj.runtime)
+		end
 
 		if project_tree and project_tree.children then
 			for _, item in ipairs(project_tree.children) do
@@ -449,22 +449,22 @@ local function find_solution(path)
 end
 
 local function find_project_for_path(state, file_path)
-       if not state.parsed_solution then
-               return nil
-       end
+	if not state.parsed_solution then
+		return nil
+	end
 
-       file_path = path_utils.normalize_path(file_path)
+	file_path = path_utils.normalize_path(file_path)
 
-       for _, proj in ipairs(state.parsed_solution:projects()) do
-               if proj.projectType ~= "solutionFolder" then
-                       local proj_dir = Path:new(proj.fullPath):parent():absolute()
-                       if file_path:sub(1, #proj_dir) == proj_dir then
-                               return proj
-                       end
-               end
-       end
+	for _, proj in ipairs(state.parsed_solution:projects()) do
+		if proj.projectType ~= "solutionFolder" then
+			local proj_dir = Path:new(proj.fullPath):parent():absolute()
+			if file_path:sub(1, #proj_dir) == proj_dir then
+				return proj
+			end
+		end
+	end
 
-       return nil
+	return nil
 end
 
 local function projects_picker(state)
@@ -672,91 +672,90 @@ local function build_project(msbuild_path, project_info)
 end
 
 local function compile_project_msbuild(msbuild_path, project_info)
-        local project_path = project_info.path
-        vim.notify(string.format("Compilando %s (%s)...", project_info.name, project_info.kind:upper()))
+	local project_path = project_info.path
+	vim.notify(string.format("Compilando %s (%s)...", project_info.name, project_info.kind:upper()))
 
-        local build_job = Job:new({
-                command = msbuild_path,
-                args = {
-                        project_path,
-                        "/t:Rebuild",
-                        "/p:Configuration=Debug",
-                        "/p:Platform=AnyCPU",
-                        "/v:minimal",
-                },
-                on_stdout = function(_, data)
-                        print(data)
-                end,
-                on_stderr = function(_, data)
-                        vim.notify(data, vim.log.levels.ERROR)
-                end,
-                on_exit = function(_, code)
-                        if code == 0 then
-                                vim.notify("✓ Compilación exitosa!", vim.log.levels.INFO)
-                        else
-                                vim.notify("✗ Error en la compilación", vim.log.levels.ERROR)
-                        end
-                end,
-        })
-        build_job:start()
+	local build_job = Job:new({
+		command = msbuild_path,
+		args = {
+			project_path,
+			"/t:Rebuild",
+			"/p:Configuration=Debug",
+			"/p:Platform=AnyCPU",
+			"/v:minimal",
+		},
+		on_stdout = function(_, data)
+			print(data)
+		end,
+		on_stderr = function(_, data)
+			vim.notify(data, vim.log.levels.ERROR)
+		end,
+		on_exit = function(_, code)
+			if code == 0 then
+				vim.notify("✓ Compilación exitosa!", vim.log.levels.INFO)
+			else
+				vim.notify("✗ Error en la compilación", vim.log.levels.ERROR)
+			end
+		end,
+	})
+	build_job:start()
 end
 
 local function compile_project_dotnet(project_info)
-       local project_path = project_info.path
-       vim.notify(string.format("Compilando %s (%s)...", project_info.name, project_info.kind:upper()))
+	local project_path = project_info.path
+	vim.notify(string.format("Compilando %s (%s)...", project_info.name, project_info.kind:upper()))
 
-       local build_job = Job:new({
-               command = "dotnet",
-               args = { "build", project_path },
-               on_stdout = function(_, data)
-                       print(data)
-               end,
-               on_stderr = function(_, data)
-                       vim.notify(data, vim.log.levels.ERROR)
-               end,
-               on_exit = function(_, code)
-                       if code == 0 then
-                               vim.notify("✓ Compilación exitosa!", vim.log.levels.INFO)
-                       else
-                               vim.notify("✗ Error en la compilación", vim.log.levels.ERROR)
-                       end
-               end,
-       })
-       build_job:start()
+	local build_job = Job:new({
+		command = "dotnet",
+		args = { "build", project_path },
+		on_stdout = function(_, data)
+			print(data)
+		end,
+		on_stderr = function(_, data)
+			vim.notify(data, vim.log.levels.ERROR)
+		end,
+		on_exit = function(_, code)
+			if code == 0 then
+				vim.notify("✓ Compilación exitosa!", vim.log.levels.INFO)
+			else
+				vim.notify("✗ Error en la compilación", vim.log.levels.ERROR)
+			end
+		end,
+	})
+	build_job:start()
 end
 
 local function run_project_dotnet(project_info)
-       local cmd = { "dotnet", "run", "--project", project_info.path }
-       vim.fn.termopen(cmd)
+	local cmd = { "dotnet", "run", "--project", project_info.path }
+	vim.fn.termopen(cmd)
 end
 
 local function add_file_to_csproj(csproj_path, rel_path)
-       local lines = vim.fn.readfile(csproj_path)
-       local insert_pos = nil
-       for idx, line in ipairs(lines) do
-               if line:match("</ItemGroup>") then
-                       insert_pos = idx
-                       break
-               end
-       end
+	local lines = vim.fn.readfile(csproj_path)
+	local insert_pos = nil
+	for idx, line in ipairs(lines) do
+		if line:match("</ItemGroup>") then
+			insert_pos = idx
+			break
+		end
+	end
 
-       local compile_line = string.format('    <Compile Include="%s" />', rel_path)
+	local compile_line = string.format('    <Compile Include="%s" />', rel_path)
 
-       if insert_pos then
-               table.insert(lines, insert_pos, compile_line)
-       else
-               table.insert(lines, #lines, '  <ItemGroup>')
-               table.insert(lines, #lines, compile_line)
-               table.insert(lines, #lines, '  </ItemGroup>')
-       end
+	if insert_pos then
+		table.insert(lines, insert_pos, compile_line)
+	else
+		table.insert(lines, #lines, "  <ItemGroup>")
+		table.insert(lines, #lines, compile_line)
+		table.insert(lines, #lines, "  </ItemGroup>")
+	end
 
-       vim.fn.writefile(lines, csproj_path)
+	vim.fn.writefile(lines, csproj_path)
 end
 
 local function create_file(full_path, template)
-       Path:new(full_path):write(template or "", "w")
+	Path:new(full_path):write(template or "", "w")
 end
-
 
 local function get_iis_express_path()
 	local program_files = os.getenv("ProgramFiles(x86)") or os.getenv("ProgramFiles")
@@ -868,135 +867,135 @@ function M.build_and_run()
 end
 
 function M.build_current_project()
-       local state = require("neo-tree.sources.manager").get_state(M.name)
-       if not state or not state.tree then
-               return
-       end
-       local node = state.tree:get_node()
-       if not node or not node.path or not node.path:match("%.csproj$") then
-               vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
-               return
-       end
+	local state = require("neo-tree.sources.manager").get_state(M.name)
+	if not state or not state.tree then
+		return
+	end
+	local node = state.tree:get_node()
+	if not node or not node.path or not node.path:match("%.csproj$") then
+		vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
+		return
+	end
 
-       local project_info = {
-               path = node.path,
-               name = node.name,
-               kind = node.kind or "library",
-               runtime = node.runtime,
-       }
+	local project_info = {
+		path = node.path,
+		name = node.name,
+		kind = node.kind or "library",
+		runtime = node.runtime,
+	}
 
-       if project_info.runtime and is_net_framework(project_info.runtime) then
-               if vim.fn.has("win32") ~= 1 then
-                       vim.notify("Los proyectos de .NET Framework solo funcionan en Windows", vim.log.levels.ERROR)
-                       return
-               end
+	if project_info.runtime and is_net_framework(project_info.runtime) then
+		if vim.fn.has("win32") ~= 1 then
+			vim.notify("Los proyectos de .NET Framework solo funcionan en Windows", vim.log.levels.ERROR)
+			return
+		end
 
-               local msbuild_path = find_msbuild()
-               if not msbuild_path then
-                       vim.ui.select({ "Sí", "No" }, {
-                               prompt = "MSBuild no encontrado. ¿Instalar Build Tools?",
-                       }, function(choice)
-                               if choice == "Sí" then
-                                       install_build_tools()
-                               end
-                       end)
-                       return
-               end
+		local msbuild_path = find_msbuild()
+		if not msbuild_path then
+			vim.ui.select({ "Sí", "No" }, {
+				prompt = "MSBuild no encontrado. ¿Instalar Build Tools?",
+			}, function(choice)
+				if choice == "Sí" then
+					install_build_tools()
+				end
+			end)
+			return
+		end
 
-               compile_project_msbuild(msbuild_path, project_info)
-       else
-               if vim.fn.executable("dotnet") ~= 1 then
-                       vim.notify("dotnet CLI no encontrada en el PATH", vim.log.levels.ERROR)
-                       return
-               end
-               compile_project_dotnet(project_info)
-       end
+		compile_project_msbuild(msbuild_path, project_info)
+	else
+		if vim.fn.executable("dotnet") ~= 1 then
+			vim.notify("dotnet CLI no encontrada en el PATH", vim.log.levels.ERROR)
+			return
+		end
+		compile_project_dotnet(project_info)
+	end
 end
 
 function M.run_current_project()
-       local state = require("neo-tree.sources.manager").get_state(M.name)
-       if not state or not state.tree then
-               return
-       end
+	local state = require("neo-tree.sources.manager").get_state(M.name)
+	if not state or not state.tree then
+		return
+	end
 
-       local node = state.tree:get_node()
-       if not node or not node.path or not node.path:match("%.csproj$") then
-               vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
-               return
-       end
+	local node = state.tree:get_node()
+	if not node or not node.path or not node.path:match("%.csproj$") then
+		vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
+		return
+	end
 
-       local project_info = {
-               path = node.path,
-               name = node.name,
-               kind = node.kind or "console",
-               runtime = node.runtime,
-       }
+	local project_info = {
+		path = node.path,
+		name = node.name,
+		kind = node.kind or "console",
+		runtime = node.runtime,
+	}
 
-       if not is_dotnet_cli_runtime(project_info.runtime) then
-               vim.notify("DotNetRun solo soporta proyectos .NET", vim.log.levels.ERROR)
-               return
-       end
+	if not is_dotnet_cli_runtime(project_info.runtime) then
+		vim.notify("DotNetRun solo soporta proyectos .NET", vim.log.levels.ERROR)
+		return
+	end
 
-       if vim.fn.executable("dotnet") ~= 1 then
-               vim.notify("dotnet CLI no encontrada en el PATH", vim.log.levels.ERROR)
-               return
-       end
+	if vim.fn.executable("dotnet") ~= 1 then
+		vim.notify("dotnet CLI no encontrada en el PATH", vim.log.levels.ERROR)
+		return
+	end
 
-       run_project_dotnet(project_info)
+	run_project_dotnet(project_info)
 end
 
 function M.create_new_file()
-       local state = require("neo-tree.sources.manager").get_state(M.name)
-       if not state or not state.tree then
-               return
-       end
+	local state = require("neo-tree.sources.manager").get_state(M.name)
+	if not state or not state.tree then
+		return
+	end
 
-       local node = state.tree:get_node()
-       if not node then
-               return
-       end
+	local node = state.tree:get_node()
+	if not node then
+		return
+	end
 
-       local dir_path = node.path
-       if node.type ~= "directory" then
-               dir_path = Path:new(node.path):parent():absolute()
-       elseif dir_path:match("%.csproj$") then
-               dir_path = Path:new(dir_path):parent():absolute()
-       end
+	local dir_path = node.path
+	if node.type ~= "directory" then
+		dir_path = Path:new(node.path):parent():absolute()
+	elseif dir_path:match("%.csproj$") then
+		dir_path = Path:new(dir_path):parent():absolute()
+	end
 
-       vim.ui.input({ prompt = "Nombre del archivo:" }, function(input)
-               if not input or input == "" then
-                       return
-               end
+	vim.ui.input({ prompt = "Nombre del archivo:" }, function(input)
+		if not input or input == "" then
+			return
+		end
 
-               local full_path = Path:new(dir_path, input):absolute()
-               if vim.fn.filereadable(full_path) == 1 then
-                       vim.notify("El archivo ya existe", vim.log.levels.ERROR)
-                       return
-               end
+		local full_path = Path:new(dir_path, input):absolute()
+		if vim.fn.filereadable(full_path) == 1 then
+			vim.notify("El archivo ya existe", vim.log.levels.ERROR)
+			return
+		end
 
-               local template = ""
-               if input:match("%.cs$") then
-                       local class_name = input:gsub("%.cs$", "")
-                       template = string.format("public class %s\n{\n}\n", class_name)
-               end
+		local template = ""
+		if input:match("%.cs$") then
+			local class_name = input:gsub("%.cs$", "")
+			template = string.format("public class %s\n{\n}\n", class_name)
+		end
 
-               create_file(full_path, template)
+		create_file(full_path, template)
 
-               local proj = find_project_for_path(state, full_path)
-               if proj then
-                       local proj_tree = state.project_trees[proj.fullPath]
-                       if proj_tree and not proj_tree.is_sdk_style then
-                               local proj_dir = Path:new(proj.fullPath):parent():absolute()
-                               local rel = Path:new(full_path):make_relative(proj_dir)
-                               add_file_to_csproj(proj.fullPath, rel)
-                       end
-               end
+		local proj = find_project_for_path(state, full_path)
+		if proj then
+			local proj_tree = state.project_trees[proj.fullPath]
+			if proj_tree and not proj_tree.is_sdk_style then
+				local proj_dir = Path:new(proj.fullPath):parent():absolute()
+				local rel = Path:new(full_path):make_relative(proj_dir)
+				add_file_to_csproj(proj.fullPath, rel)
+			end
+		end
 
-               state.last_scan = 0
-               manager.refresh(M.name)
+		state.last_scan = 0
+		manager.refresh(M.name)
 
-               vim.cmd("edit " .. full_path)
-       end)
+		vim.cmd("edit " .. full_path)
+	end)
 end
 
 -- Comando de usuario

--- a/lua/dotnet-solution-explorer/init.lua
+++ b/lua/dotnet-solution-explorer/init.lua
@@ -169,28 +169,31 @@ local function project_to_node(state, proj, known_nodes)
 	end
 	known_nodes[proj.fullPath] = true
 
-	local node = {
-		id = proj.fullPath,
-		name = proj.projectName,
-		path = proj.fullPath,
-		type = "directory",
-		icon = (proj.projectType == "solutionFolder") and ICONS.FOLDER or ICONS.PROJECT,
-		children = {},
-	}
+        local node = {
+                id = proj.fullPath,
+                name = proj.projectName,
+                path = proj.fullPath,
+                type = "directory",
+                icon = (proj.projectType == "solutionFolder") and ICONS.FOLDER or ICONS.PROJECT,
+                children = {},
+                kind = proj.kind,
+        }
 
 	if
 		proj.projectType == "knownToBeMSBuildFormat"
 		or proj.projectType == "webProject"
 		or proj.projectType == "webDeploymentProject"
 	then
-		local project_tree = state.project_trees[proj.fullPath]
-		if not project_tree then
-			project_tree = parse_project_safe(proj.fullPath)
-			if project_tree then
-				proj.kind = project_tree.kind
-				state.project_trees[proj.fullPath] = project_tree
-			end
-		end
+                local project_tree = state.project_trees[proj.fullPath]
+                if not project_tree then
+                        project_tree = parse_project_safe(proj.fullPath)
+                        if project_tree then
+                                proj.kind = project_tree.kind
+                                state.project_trees[proj.fullPath] = project_tree
+                        end
+                end
+
+                node.kind = proj.kind
 
 		if project_tree and project_tree.children then
 			for _, item in ipairs(project_tree.children) do
@@ -612,6 +615,36 @@ local function build_project(msbuild_path, project_info)
 	build_job:start()
 end
 
+local function compile_project(msbuild_path, project_info)
+        local project_path = project_info.path
+        vim.notify(string.format("Compilando %s (%s)...", project_info.name, project_info.kind:upper()))
+
+        local build_job = Job:new({
+                command = msbuild_path,
+                args = {
+                        project_path,
+                        "/t:Rebuild",
+                        "/p:Configuration=Debug",
+                        "/p:Platform=AnyCPU",
+                        "/v:minimal",
+                },
+                on_stdout = function(_, data)
+                        print(data)
+                end,
+                on_stderr = function(_, data)
+                        vim.notify(data, vim.log.levels.ERROR)
+                end,
+                on_exit = function(_, code)
+                        if code == 0 then
+                                vim.notify("✓ Compilación exitosa!", vim.log.levels.INFO)
+                        else
+                                vim.notify("✗ Error en la compilación", vim.log.levels.ERROR)
+                        end
+                end,
+        })
+        build_job:start()
+end
+
 local function get_iis_express_path()
 	local program_files = os.getenv("ProgramFiles(x86)") or os.getenv("ProgramFiles")
 	local paths = {
@@ -721,8 +754,41 @@ function M.build_and_run()
 	build_project(msbuild_path, project_info) -- Pasamos el objeto completo
 end
 
+function M.build_current_project()
+        local state = require("neo-tree.sources.manager").get_state(M.name)
+        if not state or not state.tree then
+                return
+        end
+        local node = state.tree:get_node()
+        if not node or not node.path or not node.path:match("%.csproj$") then
+                vim.notify("Seleccione un proyecto válido", vim.log.levels.ERROR)
+                return
+        end
+
+        local project_info = {
+                path = node.path,
+                name = node.name,
+                kind = node.kind or "library",
+        }
+
+        local msbuild_path = find_msbuild()
+        if not msbuild_path then
+                vim.ui.select({ "Sí", "No" }, {
+                        prompt = "MSBuild no encontrado. ¿Instalar Build Tools?",
+                }, function(choice)
+                        if choice == "Sí" then
+                                install_build_tools()
+                        end
+                end)
+                return
+        end
+
+        compile_project(msbuild_path, project_info)
+end
+
 -- Comando de usuario
 vim.api.nvim_create_user_command("DotNetFrameworkRun", M.build_and_run, {})
+vim.api.nvim_create_user_command("DotNetFrameworkBuild", M.build_current_project, {})
 
 -- Autodetección de entorno al cargar el plugin
 vim.schedule(function()

--- a/lua/dotnet-solution-explorer/project_parser.lua
+++ b/lua/dotnet-solution-explorer/project_parser.lua
@@ -1,7 +1,7 @@
 local uv = vim.loop
 local Path = require("plenary.path")
 local xml2lua = require("xml2lua")
-local path_utils = require("utils.path")
+local path_utils = require("dotnet-solution-explorer.utils.path")
 
 local M = {}
 
@@ -317,12 +317,12 @@ function M.parse_project(proj_path)
 
 	local tree = build_tree(files, base_dir)
 
-        return {
-                runtime = project_info.runtime,
-                kind = detect_project_kind(project_node),
-                children = tree.children,
-                is_sdk_style = project_info.is_sdk_style,
-        }
+	return {
+		runtime = project_info.runtime,
+		kind = detect_project_kind(project_node),
+		children = tree.children,
+		is_sdk_style = project_info.is_sdk_style,
+	}
 end
 
 return M

--- a/lua/dotnet-solution-explorer/project_parser.lua
+++ b/lua/dotnet-solution-explorer/project_parser.lua
@@ -317,11 +317,12 @@ function M.parse_project(proj_path)
 
 	local tree = build_tree(files, base_dir)
 
-	return {
-		runtime = project_info.runtime,
-		kind = detect_project_kind(project_node),
-		children = tree.children,
-	}
+        return {
+                runtime = project_info.runtime,
+                kind = detect_project_kind(project_node),
+                children = tree.children,
+                is_sdk_style = project_info.is_sdk_style,
+        }
 end
 
 return M


### PR DESCRIPTION
## Summary
- add `DotNetFrameworkBuild` command that builds the project under the cursor
- expose `build_project` command for Neo-tree mappings
- include new compile logic
- document project build mapping in README

## Testing
- `luac -p $(find lua -name '*.lua')`

------
https://chatgpt.com/codex/tasks/task_e_688a65fa0fb0832d8acff89704ca5ec1