### PR TITLE
Add debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A Neo-tree source that brings a Visual Studio style Solution Explorer to Neovim.
   dependencies = { "nvim-neo-tree/neo-tree.nvim", "nvim-lua/plenary.nvim" },
   config = function()
     require("dotnet-solution-explorer").setup({
+      -- Set to true to enable verbose debug output
+      debug = false,
       follow_current_file = { enabled = true },
     })
   end,
@@ -72,6 +74,17 @@ require("neo-tree").setup({
       ["a"] = "add_file",
     },
   },
+})
+```
+
+## Debugging
+
+Set `debug = true` in the setup call to print verbose messages while the source
+is loading and parsing projects:
+
+```lua
+require("dotnet-solution-explorer").setup({
+  debug = true,
 })
 ```
 

--- a/lua/dotnet-solution-explorer/init.lua
+++ b/lua/dotnet-solution-explorer/init.lua
@@ -55,8 +55,13 @@ local function is_dotnet_cli_runtime(runtime)
 	return false
 end
 
+local debug_enabled = false
+
 local function debug_log(message, data)
-	-- print(string.format("[Solution Explorer Debug] %s -> %s", message, vim.inspect(data)))
+        if not debug_enabled then
+                return
+        end
+        print(string.format("[Solution Explorer Debug] %s -> %s", message, vim.inspect(data)))
 end
 
 local function find_and_parse_solution(state, sln_file_path)
@@ -1035,7 +1040,10 @@ vim.schedule(function()
 end)
 
 M.setup = function(config, global_config)
-	utils.register_stat_provider("solution-explorer", M.get_node_stat)
+        config = config or {}
+        debug_enabled = config.debug or false
+
+        utils.register_stat_provider("solution-explorer", M.get_node_stat)
 
 	manager.subscribe(M.name, {
 		event = events.FS_EVENT,

--- a/lua/dotnet-solution-explorer/init.lua
+++ b/lua/dotnet-solution-explorer/init.lua
@@ -58,10 +58,10 @@ end
 local debug_enabled = false
 
 local function debug_log(message, data)
-        if not debug_enabled then
-                return
-        end
-        print(string.format("[Solution Explorer Debug] %s -> %s", message, vim.inspect(data)))
+	if not debug_enabled then
+		return
+	end
+	print(string.format("[Solution Explorer Debug] %s -> %s", message, vim.inspect(data)))
 end
 
 local function find_and_parse_solution(state, sln_file_path)
@@ -1012,38 +1012,41 @@ vim.api.nvim_create_user_command("DotNetAddFile", M.create_new_file, {})
 
 -- Autodetección de entorno al cargar el plugin
 vim.schedule(function()
-       local ok = pcall(require, "xml2lua")
-       if not ok then
-               if vim.fn.executable("luarocks") == 1 then
-                       vim.notify("Instalando dependencia xml2lua...", vim.log.levels.INFO)
-                       Job:new({
-                               command = "luarocks",
-                               args = { "install", "xml2lua" },
-                               on_exit = function(_, code)
-                                       if code == 0 then
-                                               vim.notify("xml2lua instalado correctamente", vim.log.levels.INFO)
-                                       else
-                                               vim.notify("No se pudo instalar xml2lua. Instálalo manualmente con 'luarocks install xml2lua'", vim.log.levels.ERROR)
-                                       end
-                               end,
-                       }):start()
-               else
-                       vim.notify("Dependencia faltante: xml2lua. Instálala con 'luarocks install xml2lua'", vim.log.levels.ERROR)
-               end
-       end
-       if vim.fn.has("win32") == 1 then
-               local msbuild = find_msbuild()
-               if not msbuild then
-                       vim.notify("Requerido: Visual Studio Build Tools para proyectos .NET Framework", vim.log.levels.WARN)
-               end
-        end
+	local ok = pcall(require, "xml2lua")
+	if not ok then
+		if vim.fn.executable("luarocks") == 1 then
+			vim.notify("Instalando dependencia xml2lua...", vim.log.levels.INFO)
+			Job:new({
+				command = "luarocks",
+				args = { "install", "xml2lua" },
+				on_exit = function(_, code)
+					if code == 0 then
+						vim.notify("xml2lua instalado correctamente", vim.log.levels.INFO)
+					else
+						vim.notify(
+							"No se pudo instalar xml2lua. Instálalo manualmente con 'luarocks install xml2lua'",
+							vim.log.levels.ERROR
+						)
+					end
+				end,
+			}):start()
+		else
+			vim.notify("Dependencia faltante: xml2lua. Instálala con 'luarocks install xml2lua'", vim.log.levels.ERROR)
+		end
+	end
+	if vim.fn.has("win32") == 1 then
+		local msbuild = find_msbuild()
+		if not msbuild then
+			vim.notify("Requerido: Visual Studio Build Tools para proyectos .NET Framework", vim.log.levels.WARN)
+		end
+	end
 end)
 
 M.setup = function(config, global_config)
-        config = config or {}
-        debug_enabled = config.debug or false
+	config = config or { follow_current_file = { enabled = false } }
+	debug_enabled = config.debug or false
 
-        utils.register_stat_provider("solution-explorer", M.get_node_stat)
+	utils.register_stat_provider("solution-explorer", M.get_node_stat)
 
 	manager.subscribe(M.name, {
 		event = events.FS_EVENT,


### PR DESCRIPTION
## Summary
- add a `debug` flag to enable verbose output
- document how to enable debugging

## Testing
- `luac -p $(find lua -name '*.lua')`


------
https://chatgpt.com/codex/tasks/task_e_688cd4676840832d8b654f15dd7fb399